### PR TITLE
Add timestamp args

### DIFF
--- a/lib/fast_osc/version.rb
+++ b/lib/fast_osc/version.rb
@@ -1,3 +1,3 @@
 module FastOsc
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/test/fast_osc_test.rb
+++ b/test/fast_osc_test.rb
@@ -75,6 +75,15 @@ class FastOscTest < Minitest::Test
     assert_equal args.map {|x| x.is_a?(Symbol) ? x.to_s : x}, outargs.map {|x| x.is_a?(Float) ? x.round(5) : x }
   end
 
+  def test_that_it_encodes_and_decodes_messages_with_timestamps
+    path = "/s_new"
+    args = [Time.at(1463234577.688746)]
+    outpath, outargs = FastOsc.decode_single_message(FastOsc.encode_single_message(path, args))
+
+    assert_equal path, outpath
+    assert_equal args, outargs
+  end
+
   def test_that_encoded_timestamps_line_up
     # this test is a bit convoluted but I found that fractional
     # seconds weren't working when I plugged this into Sonic Pi

--- a/test/fast_osc_test.rb
+++ b/test/fast_osc_test.rb
@@ -77,11 +77,12 @@ class FastOscTest < Minitest::Test
 
   def test_that_it_encodes_and_decodes_messages_with_timestamps
     path = "/s_new"
-    args = [Time.at(1463234577.688746)]
+    args = [Time.at(1463234577.488746)]
+    #args = [Time.at(1463234577.0)]
     outpath, outargs = FastOsc.decode_single_message(FastOsc.encode_single_message(path, args))
 
     assert_equal path, outpath
-    assert_equal args, outargs
+    assert_equal args.first.to_f.round(5), outargs.first.to_f.round(5)
   end
 
   def test_that_encoded_timestamps_line_up


### PR DESCRIPTION
Providing a Ruby `Time` object as an arg will encode and decode
successfully with this update.

Some inspiration for the implementation was taken from
https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/rb_grpc.c for
interfacing with `Time` from C (using `rb_cTime`) and also from this
goLang implementation of OSC
https://github.com/scgolang/osc/blob/master/timetag.go#L37

This SO post was also helpful in converting from the NTP timestamp format to seconds and usecs since the Unix epoch http://stackoverflow.com/a/29138806
