### PR TITLE
Add decoding of OSC bundles

### DIFF
--- a/ext/fast_osc/extconf.rb
+++ b/ext/fast_osc/extconf.rb
@@ -21,7 +21,7 @@ dir_config(extension_name, HEADER_DIRS, LIB_DIRS)
 #   $LOCAL_LIBS << "#{lib} "
 # end
 
-$srcs = ["fast_osc_wrapper.c"]
+$srcs = ["fast_osc_wrapper.c", "rtosc.c"]
 
 $CFLAGS << " -std=c99 -Wall -Wextra -Wno-unused-parameter -pedantic "
 

--- a/ext/fast_osc/fast_osc_wrapper.c
+++ b/ext/fast_osc/fast_osc_wrapper.c
@@ -75,10 +75,10 @@ uint64_t ruby_time_to_osc_timetag(VALUE rubytime) {
 VALUE osc_timetag_to_ruby_time(uint64_t timetag) {
   uint32_t secs = timetag >> 32;
   uint32_t frac = timetag;
+  double d_frac = 1.0 * frac / 4294967296.0;
 
-  // Time.at(seconds, microsecs_with_frac)
   VALUE c_time = rb_const_get(rb_cObject, rb_intern("Time"));
-  VALUE rb_time = rb_funcall(c_time, rb_intern("at"), 2, UINT2NUM(secs - JAN_1970), DBL2NUM(1.0 * frac / 4294967296.0));
+  VALUE rb_time = rb_funcall(c_time, rb_intern("at"), 1, DBL2NUM((secs - JAN_1970 + d_frac)));
 
   return rb_time;
 }

--- a/ext/fast_osc/fast_osc_wrapper.c
+++ b/ext/fast_osc/fast_osc_wrapper.c
@@ -74,7 +74,7 @@ uint64_t ruby_time_to_osc_timetag(VALUE rubytime) {
 
 VALUE osc_timetag_to_ruby_time(uint64_t timetag) {
   uint32_t secs = timetag >> 32;
-  uint32_t frac = timetag & 32;
+  uint32_t frac = timetag;
 
   // Time.at(seconds, microsecs_with_frac)
   VALUE c_time = rb_const_get(rb_cObject, rb_intern("Time"));

--- a/ext/fast_osc/fast_osc_wrapper.c
+++ b/ext/fast_osc/fast_osc_wrapper.c
@@ -1,7 +1,6 @@
 #include <ruby.h>
 #include <ruby/encoding.h>
 #include <rtosc.h>
-#include <rtosc.c>
 
 
 // Allocate VALUE variables to hold the modules we'll create. Ruby values

--- a/ext/fast_osc/fast_osc_wrapper.c
+++ b/ext/fast_osc/fast_osc_wrapper.c
@@ -35,7 +35,7 @@ void Init_fast_osc() {
   rb_define_singleton_method(FastOsc, "decode_single_message", method_fast_osc_decode_single_message, 1);
   rb_define_singleton_method(FastOsc, "encode_single_message", method_fast_osc_encode_single_message, -1);
   rb_define_singleton_method(FastOsc, "encode_single_bundle", method_fast_osc_encode_single_bundle, -1);
-  rb_define_singleton_method(FastOsc, "is_bundle", method_fast_osc_is_bundle, 1);
+  rb_define_singleton_method(FastOsc, "is_bundle?", method_fast_osc_is_bundle, 1);
   rb_define_singleton_method(FastOsc, "decode_bundle", method_fast_osc_decode_bundle, 1);
 }
 

--- a/ext/fast_osc/fast_osc_wrapper.c
+++ b/ext/fast_osc/fast_osc_wrapper.c
@@ -2,7 +2,6 @@
 #include <ruby/encoding.h>
 #include <rtosc.h>
 #include <rtosc.c>
-#include <math.h>
 
 
 // Allocate VALUE variables to hold the modules we'll create. Ruby values
@@ -79,7 +78,7 @@ VALUE osc_timetag_to_ruby_time(uint64_t timetag) {
 
   // Time.at(seconds, microsecs_with_frac)
   VALUE c_time = rb_const_get(rb_cObject, rb_intern("Time"));
-  VALUE rb_time = rb_funcall(c_time, rb_intern("at"), 2, UINT2NUM(secs - JAN_1970), DBL2NUM(1.0 * frac / pow(2, 32)));
+  VALUE rb_time = rb_funcall(c_time, rb_intern("at"), 2, UINT2NUM(secs - JAN_1970), DBL2NUM(1.0 * frac / 4294967296.0));
 
   return rb_time;
 }

--- a/ext/fast_osc/rtosc.c
+++ b/ext/fast_osc/rtosc.c
@@ -6,7 +6,7 @@
 #include <ctype.h>
 #include <assert.h>
 
-// #include <rtosc.h>
+#include <rtosc.h>
 
 const char *rtosc_argument_string(const char *msg)
 {

--- a/test/fast_osc_test.rb
+++ b/test/fast_osc_test.rb
@@ -58,8 +58,8 @@ class FastOscTest < Minitest::Test
   end
 
   def test_that_it_detects_bundles_properly
-    assert_equal true, FastOsc.is_bundle(@encoded_bundle)
-    assert_equal false, FastOsc.is_bundle(@encoded_msg0)
+    assert_equal true, FastOsc.is_bundle?(@encoded_bundle)
+    assert_equal false, FastOsc.is_bundle?(@encoded_msg0)
   end
 
   def test_that_it_decodes_a_bundle


### PR DESCRIPTION
The new function _decode_bundle_, returns (timestamp, msgs), where msgs contains all the messages in the bundle). In case that it is called on something that is not really a bundle it will return nil.
There is also a function _is_bundle_ to check if the packet is really a bundle.

I have added some tests as well.